### PR TITLE
♻️ (users): refactor user registration to simplify response handling

### DIFF
--- a/server/internal/common/users.go
+++ b/server/internal/common/users.go
@@ -25,6 +25,10 @@ type (
 		SubcategoryID   *string               `form:"subcategory_id,omitempty"`
 	}
 
+	RegisterUserResponse struct {
+		Message string `json:"message"`
+	}
+
 	LoginUserRequest struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`

--- a/server/internal/modules/users/handler.go
+++ b/server/internal/modules/users/handler.go
@@ -79,7 +79,7 @@ func (h userHandler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res, err := h.usersService.Register(ctx, formData)
+	err = h.usersService.Register(ctx, formData)
 	if err != nil {
 		var apiErr *exceptions.ApiError[string]
 		if castedErr, ok := err.(*exceptions.ApiError[string]); ok {
@@ -91,23 +91,5 @@ func (h userHandler) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	commonUser := &common.User{
-		ID:            res.ID(),
-		Name:          res.Name(),
-		Email:         res.Email(),
-		Role:          res.Role(),
-		AvatarURL:     res.AvatarURL(),
-		SubcategoryID: nil,
-	}
-
-	if res.SubcategoryID() != "" {
-		subID := res.SubcategoryID()
-		commonUser.SubcategoryID = &subID
-	}
-
-	userResponse := &common.UserResponse{
-		User: commonUser,
-	}
-
-	httphelpers.WriteJSON(w, http.StatusCreated, userResponse)
+	httphelpers.WriteJSON(w, http.StatusCreated, common.RegisterUserResponse{Message: "success"})
 }

--- a/server/internal/modules/users/interface.go
+++ b/server/internal/modules/users/interface.go
@@ -17,7 +17,7 @@ type (
 		DeleteByID(ctx context.Context, ID string) error
 	}
 	UsersService interface {
-		Register(ctx context.Context, input common.RegisterUserRequest) (*User, error)
+		Register(ctx context.Context, input common.RegisterUserRequest) error
 		GetByID(ctx context.Context, ID string) (*User, error)
 		GetByEmail(ctx context.Context, email string) (*User, error)
 		// Updated(ctx context.Context common.)


### PR DESCRIPTION
Refactor the user registration process to return a simple success message instead of detailed user information. This change simplifies the response structure and aligns with the need for a more concise response format.